### PR TITLE
Refactor project structure and add Python bindings to support proxying requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .env
 .DS_Store
+.ruff_cache
 
 # Misc
 training.jsonl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,12 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1033,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1241,32 +1250,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1681,6 +1733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,7 +2062,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
 name = "unremark"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cc",
+ "colored",
+ "dirs",
+ "dotenv",
+ "env_logger",
+ "futures",
+ "ignore",
+ "indicatif",
+ "log",
+ "parking_lot",
+ "pyo3",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml",
+ "tree-sitter",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
+ "walkdir",
+ "wiremock",
+]
+
+[[package]]
+name = "unremark_cli"
 version = "0.1.0"
 dependencies = [
  "cc",
@@ -2018,7 +2114,6 @@ dependencies = [
  "indicatif",
  "log",
  "parking_lot",
- "rayon",
  "regex",
  "reqwest",
  "serde",
@@ -2026,11 +2121,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
- "tree-sitter",
- "tree-sitter-javascript",
- "tree-sitter-python",
- "tree-sitter-rust",
- "tree-sitter-typescript",
+ "unremark",
  "walkdir",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [workspace]
 members = [
     "crates/unremark",
+    "crates/unremark_cli",
     "crates/unremark_server"
 ]
 resolver = "2"
+default-members = ["crates/unremark_cli"]
 
 [workspace.dependencies]
-unremark = { path = "crates/unremark" }
-unremark_server = { path = "crates/unremark_server" }
-
 dotenv = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/unremark/requirements.txt
+++ b/crates/unremark/requirements.txt
@@ -1,0 +1,10 @@
+asgiref==3.8.1
+cffi==1.17.1
+Django==5.1.5
+djangorestframework==3.15.2
+maturin==1.8.1
+psycopg2==2.9.10
+pycparser==2.22
+python-decouple==3.8
+sqlparse==0.5.3
+-e git+https://github.com/software-trizzey/unremark.git@773ac28dba5d601dec49a9edd1b4411e42eaeee2#egg=unremark

--- a/crates/unremark/src/bindings/mod.rs
+++ b/crates/unremark/src/bindings/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod python;

--- a/crates/unremark/src/bindings/python.rs
+++ b/crates/unremark/src/bindings/python.rs
@@ -1,0 +1,53 @@
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "python")]
+use crate::types::Language;
+
+#[cfg(feature = "python")]
+use crate::comment_detection::detect_comments;
+
+#[cfg(feature = "python")]
+#[pyclass]
+pub struct PyCommentInfo {
+    #[pyo3(get)]
+    text: String,
+    #[pyo3(get)]
+    line_number: usize,
+    #[pyo3(get)]
+    context: String,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyCommentInfo {
+    #[new]
+    fn new(text: String, line_number: usize, context: String) -> Self {
+        Self { text, line_number, context }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+pub fn py_analyze_comments(source_code: &str, language: &str) -> PyResult<Vec<PyCommentInfo>> {
+    let lang = Language::from_extension(language)
+        .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>("Unsupported language"))?;
+    
+    let comments = detect_comments(source_code, lang)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    
+    Ok(comments.into_iter()
+        .map(|c| PyCommentInfo {
+            text: c.text,
+            line_number: c.line_number,
+            context: c.context,
+        })
+        .collect())
+}
+
+#[cfg(feature = "python")]
+pub fn register_module(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyCommentInfo>()?;
+    m.add_function(wrap_pyfunction!(py_analyze_comments, m)?)?;
+    Ok(())
+} 

--- a/crates/unremark/src/comment_detection.rs
+++ b/crates/unremark/src/comment_detection.rs
@@ -1,0 +1,60 @@
+use crate::types::{CommentInfo, Language};
+use crate::utils::find_context;
+
+use log::debug;
+use tree_sitter::{Node, Parser};
+
+pub fn detect_comments(source_code: &str, language: Language) -> Result<Vec<CommentInfo>, String> {
+    let mut parser = Parser::new();
+    if parser.set_language(&language.get_tree_sitter_language()).is_err() {
+        return Ok(vec![]);
+    }
+
+    let tree = match parser.parse(source_code, None) {
+        Some(tree) => tree,
+        None => return Ok(vec![]),
+    };
+
+    if tree.root_node().has_error() {
+        return Ok(vec![]);
+    }
+
+    Ok(collect_comments(tree.root_node(), source_code))
+}
+
+fn collect_comments(node: Node, code: &str) -> Vec<CommentInfo> {
+    let mut comments = Vec::new();
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        debug!("Node kind: {} at line {}", child.kind(), child.start_position().row + 1);
+        if child.kind().contains("comment") {
+            let comment_text = code[child.byte_range()].trim().to_string();
+            
+            // Skip documentation comments for all supported languages
+            if comment_text.starts_with("///") ||    // Rust doc comments
+               comment_text.starts_with("//!") ||    // Rust module doc comments
+               comment_text.starts_with("/**") ||    // JSDoc/TSDoc/Rust block doc comments
+               comment_text.starts_with("/*!")  ||   // Rust module block doc comments
+               comment_text.starts_with("\"\"\"") || // Python docstrings
+               comment_text.starts_with("'''") {     // Python docstrings (alternative)
+                debug!("Skipping doc comment: {}", comment_text);
+                continue;
+            }
+
+            let line_number = child.start_position().row + 1;
+            let context = find_context(child, code);
+
+            debug!("Found comment: '{}' of type '{}' on line {}", 
+                comment_text, child.kind(), line_number);
+
+            comments.push(CommentInfo {
+                text: comment_text,
+                line_number,
+                context,
+            });
+        }
+        comments.extend(collect_comments(child, code));
+    }
+    comments
+} 

--- a/crates/unremark/src/constants.rs
+++ b/crates/unremark/src/constants.rs
@@ -1,0 +1,4 @@
+pub const OPENAI_MODEL: &str = "ft:gpt-4o-mini-2024-07-18:personal:unremark:Aq45wBQq"; 
+
+pub const CACHE_FILE_NAME: &str = "unremark_cache.json";
+pub const PROXY_ENDPOINT: &str = "http://localhost:5000/analyze"; // TODO: update when we have a proxy

--- a/crates/unremark/src/lib.rs
+++ b/crates/unremark/src/lib.rs
@@ -1,8 +1,3 @@
-use std::path::PathBuf;
-use std::fs;
-use log::debug;
-
-// Public exports
 pub use crate::types::{
     Language,
     CommentInfo,
@@ -12,26 +7,32 @@ pub use crate::types::{
     Cache,
     CacheEntry,
 };
-pub use crate::analysis::{analyze_file, analyze_comments, analyze_text_content};
+pub use crate::analysis::{analyze_file, analyze_comments, analyze_current_file};
 pub use crate::utils::{find_context, remove_redundant_comments};
+pub use crate::comment_detection::detect_comments;
+pub use crate::constants::{OPENAI_MODEL, CACHE_FILE_NAME, PROXY_ENDPOINT};
+pub use services::proxy::{ProxyAnalysisService, AnalysisService, create_analysis_service};
 
 // Internal modules
 mod types;
+mod constants;
 mod analysis;
 mod utils;
 mod api;
+mod comment_detection;
+mod bindings;
+mod services;
 
-// Constants
-pub const CACHE_FILE_NAME: &str = "analysis_cache.json";
 
-// Public functions
-pub fn get_cache_path() -> PathBuf {
-    let cache_dir = dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("unremark");
-    
-    debug!("Cache directory: {}", cache_dir.display());
-    fs::create_dir_all(&cache_dir).unwrap_or_default();
-    
-    cache_dir.join(CACHE_FILE_NAME)
+// Python bindings (only when python feature is enabled)
+#[cfg(feature = "python")]
+pub use bindings::python::{PyCommentInfo, py_analyze_comments, register_module};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "python")]
+#[pymodule]
+fn unremark(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    register_module(py, m)
 }

--- a/crates/unremark/src/services/mod.rs
+++ b/crates/unremark/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod proxy;

--- a/crates/unremark/src/services/proxy.rs
+++ b/crates/unremark/src/services/proxy.rs
@@ -1,0 +1,85 @@
+use async_trait::async_trait;
+use serde::{Serialize, Deserialize};
+use reqwest::Client;
+use crate::types::CommentInfo;
+use crate::constants::PROXY_ENDPOINT;
+
+#[derive(Debug, Serialize)]
+struct ProxyRequest {
+    comments: Vec<CommentInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProxyResponse {
+    redundant_comments: Vec<CommentInfo>,
+}
+
+#[async_trait]
+pub trait AnalysisService: Send + Sync {
+    async fn analyze_comments_with_proxy(&self, comments: Vec<CommentInfo>) -> Result<Vec<CommentInfo>, String>;
+}
+
+pub struct ProxyAnalysisService {
+    pub endpoint: String,
+}
+
+#[async_trait]
+impl AnalysisService for ProxyAnalysisService {
+    async fn analyze_comments_with_proxy(&self, comments: Vec<CommentInfo>) -> Result<Vec<CommentInfo>, String> {
+        let client = Client::new();
+        
+        let request = ProxyRequest { comments };
+
+        let response = client
+            .post(&format!("{}/analyze", self.endpoint))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| format!("Proxy request failed: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!("Proxy error: {}", response.status()));
+        }
+
+        let analysis: ProxyResponse = response
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse proxy response: {}", e))?;
+
+        Ok(analysis.redundant_comments)
+    }
+}
+
+pub fn create_analysis_service(proxy_endpoint: Option<String>) -> Box<dyn AnalysisService + Send + Sync> {
+    Box::new(ProxyAnalysisService {
+        endpoint: proxy_endpoint.unwrap_or_else(|| PROXY_ENDPOINT.to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_proxy_service() {
+        let service = ProxyAnalysisService {
+            endpoint: PROXY_ENDPOINT.to_string(),
+        };
+
+        let comments = vec![
+            CommentInfo {
+                text: "// Adds two numbers".to_string(),
+                line_number: 1,
+                context: "fn add(a: i32, b: i32) -> i32 { a + b }".to_string(),
+            },
+            CommentInfo {
+                text: "// Returns the sum".to_string(),
+                line_number: 2,
+                context: "a + b".to_string(),
+            },
+        ];
+
+        let result = service.analyze_comments_with_proxy(comments).await;
+        assert!(result.is_ok());
+    }
+} 

--- a/crates/unremark/src/types.rs
+++ b/crates/unremark/src/types.rs
@@ -83,11 +83,11 @@ impl Cache {
     }
 
     pub fn load() -> Self {
-        Self::load_from_path(&crate::get_cache_path())
+        Self::load_from_path(&crate::utils::get_cache_path())
     }
 
     pub fn save(&self) {
-        self.save_to_path(&crate::get_cache_path())
+        self.save_to_path(&crate::utils::get_cache_path())
     }
 }
 

--- a/crates/unremark/src/utils.rs
+++ b/crates/unremark/src/utils.rs
@@ -1,6 +1,21 @@
 use crate::types::CommentInfo;
 use tree_sitter::Node;
 use log::debug;
+use std::path::PathBuf;
+use std::fs;
+use crate::constants::CACHE_FILE_NAME;
+
+pub fn get_cache_path() -> PathBuf {
+    let cache_dir = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("unremark");
+    
+    debug!("Cache directory: {}", cache_dir.display());
+    fs::create_dir_all(&cache_dir).unwrap_or_default();
+    
+    cache_dir.join(CACHE_FILE_NAME)
+}
+
 
 pub fn find_context(node: Node, code: &str) -> String {
     let mut parent = node;

--- a/crates/unremark_cli/Cargo.toml
+++ b/crates/unremark_cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "unremark"
+name = "unremark_cli"
 version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/software-trizzey/unremark"
@@ -7,25 +7,17 @@ authors = ["Tristan Deane <tristandeane93@gmail.com>"]
 license = "MIT"
 readme = "../../README.md"
 
-[lib]
+[[bin]]
 name = "unremark"
-path = "src/lib.rs"
-crate-type = ["lib","cdylib"]  # Needed for Python bindings
-
-[features]
-python = ["pyo3"]
+path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1"
-tree-sitter = "0.24.7"
-tree-sitter-rust = "0.23.0"
-tree-sitter-python = "0.23.0"
-tree-sitter-javascript = "0.23.0"
-tree-sitter-typescript = "0.23.0"
-pyo3 = { version = "0.23.4", features = ["extension-module"], optional = true }
+unremark = { path = "../unremark" }
+
 dotenv = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+clap = { workspace = true }
 walkdir = { workspace = true }
 ignore = { workspace = true }
 toml = { workspace = true }

--- a/crates/unremark_cli/src/main.rs
+++ b/crates/unremark_cli/src/main.rs
@@ -11,7 +11,6 @@ use std::time::Instant;
 use futures::future::join_all;
 use tokio;
 
-// Import from our library
 use unremark::{
     Language,
     AnalysisResult,


### PR DESCRIPTION
## In this PR

- Split CLI functionality into separate crate
- Add Python bindings using PyO3
- Remove main binary from unremark crate
- Update Cargo.toml to support Python extension module
- Add new comment detection and services modules
- Modify analysis module to support Python and proxy services
