### PR TITLE
Feature/update python bindings and use pyo3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/crates/unremark/Cargo.toml
+++ b/crates/unremark/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 repository = "https://github.com/software-trizzey/unremark"
 authors = ["Tristan Deane <tristandeane93@gmail.com>"]
 license = "MIT"
-readme = "../../README.md"
 
 [lib]
 name = "unremark"

--- a/crates/unremark/Cargo.toml
+++ b/crates/unremark/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../../README.md"
 [lib]
 name = "unremark"
 path = "src/lib.rs"
-crate-type = ["lib","cdylib"]  # Needed for Python bindings
+crate-type = ["rlib","cdylib"]  # Needed for Python bindings
 
 [features]
 python = ["pyo3"]

--- a/crates/unremark/README.md
+++ b/crates/unremark/README.md
@@ -1,0 +1,15 @@
+# Unremark
+
+Unremark is a Rust library for analyzing and removing redundant comments from code.
+
+### Development with Python bindings
+
+- Build the package: `maturin build --features python`
+- Run tests: `maturin develop && cargo test --features python`
+- Install in editable mode: `maturin develop --features python`
+
+### Requirements
+
+- Python >= 3.8
+- Rust toolchain
+- `cffi` Python package

--- a/crates/unremark/pyproject.toml
+++ b/crates/unremark/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["maturin>=1.8,<2.0", "cffi>=1.15.0"]
+build-backend = "maturin"
+
+[project]
+name = "unremark"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = ["cffi>=1.15.0"]
+
+# TODO: Optional: Use dynamic versioning instead
+# [project]
+# name = "unremark"
+# dynamic = ["version"]
+# requires-python = ">=3.8"
+# dependencies = ["cffi>=1.15.0"] 

--- a/crates/unremark/src/constants.rs
+++ b/crates/unremark/src/constants.rs
@@ -1,4 +1,9 @@
 pub const OPENAI_MODEL: &str = "ft:gpt-4o-mini-2024-07-18:personal:unremark:Aq45wBQq"; 
 
 pub const CACHE_FILE_NAME: &str = "unremark_cache.json";
-pub const PROXY_ENDPOINT: &str = "http://localhost:5000/analyze"; // TODO: update when we have a proxy
+
+pub const DEFAULT_PROXY_ENDPOINT: &str = "http://localhost:5000/";
+
+pub fn get_proxy_endpoint() -> String {
+    std::env::var("PROXY_ENDPOINT").unwrap_or_else(|_| DEFAULT_PROXY_ENDPOINT.to_string())
+}

--- a/crates/unremark/src/lib.rs
+++ b/crates/unremark/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::types::{
 pub use crate::analysis::{analyze_file, analyze_comments, analyze_current_file};
 pub use crate::utils::{find_context, remove_redundant_comments};
 pub use crate::comment_detection::detect_comments;
-pub use crate::constants::{OPENAI_MODEL, CACHE_FILE_NAME, PROXY_ENDPOINT};
+pub use crate::constants::{OPENAI_MODEL, CACHE_FILE_NAME, get_proxy_endpoint};
 pub use services::proxy::{ProxyAnalysisService, AnalysisService, create_analysis_service};
 
 // Internal modules

--- a/crates/unremark/src/lib.rs
+++ b/crates/unremark/src/lib.rs
@@ -26,13 +26,15 @@ mod services;
 
 // Python bindings (only when python feature is enabled)
 #[cfg(feature = "python")]
-pub use bindings::python::{PyCommentInfo, py_analyze_comments, register_module};
+pub use bindings::python::{py_analyze_comments, PyCommentInfo};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 #[cfg(feature = "python")]
 #[pymodule]
-fn unremark(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    register_module(py, m)
+fn unremark(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyCommentInfo>()?;
+    m.add_function(wrap_pyfunction!(py_analyze_comments, m)?)?;
+    Ok(())
 }

--- a/crates/unremark/src/services/proxy.rs
+++ b/crates/unremark/src/services/proxy.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Serialize, Deserialize};
 use reqwest::Client;
 use crate::types::CommentInfo;
-use crate::constants::PROXY_ENDPOINT;
+use crate::constants::get_proxy_endpoint;
 
 #[derive(Debug, Serialize)]
 struct ProxyRequest {
@@ -31,7 +31,7 @@ impl AnalysisService for ProxyAnalysisService {
         let request = ProxyRequest { comments };
 
         let response = client
-            .post(&format!("{}/analyze", self.endpoint))
+            .post(&format!("{}/api/analyze", self.endpoint))
             .json(&request)
             .send()
             .await
@@ -50,12 +50,13 @@ impl AnalysisService for ProxyAnalysisService {
     }
 }
 
-pub fn create_analysis_service(proxy_endpoint: Option<String>) -> Box<dyn AnalysisService + Send + Sync> {
+pub fn create_analysis_service() -> Box<dyn AnalysisService + Send + Sync> {
     Box::new(ProxyAnalysisService {
-        endpoint: proxy_endpoint.unwrap_or_else(|| PROXY_ENDPOINT.to_string()),
+        endpoint: get_proxy_endpoint(),
     })
 }
 
+// FIXME: This should be an integration test as it depends on the proxy server
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -63,7 +64,7 @@ mod tests {
     #[tokio::test]
     async fn test_proxy_service() {
         let service = ProxyAnalysisService {
-            endpoint: PROXY_ENDPOINT.to_string(),
+            endpoint: get_proxy_endpoint(),
         };
 
         let comments = vec![

--- a/crates/unremark_server/src/main.rs
+++ b/crates/unremark_server/src/main.rs
@@ -148,7 +148,7 @@ impl UnremarkLanguageServer {
                 let redundant_comments = if std::env::var("OPENAI_API_KEY").is_ok() {
                     analyze_comments(comments).await.unwrap_or_default()
                 } else {
-                    create_analysis_service(None).analyze_comments_with_proxy(comments).await.unwrap_or_default()
+                    create_analysis_service().analyze_comments_with_proxy(comments).await.unwrap_or_default()
                 };
 
                 let diagnostics: Vec<Diagnostic> = redundant_comments


### PR DESCRIPTION
## In this PR

- Fix issues with python bindings.
- Simplify python analysis function
- Document how to use bindings with maturin package.
- Make proxy endpoint dynamic via env variable.
- Add build target flags to support Pyo3 on MacOS
